### PR TITLE
fix(table-chart): table header alignment for Chrome browser

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/DataTable/hooks/useSticky.tsx
@@ -26,6 +26,7 @@ import React, {
   ComponentPropsWithRef,
   CSSProperties,
   UIEventHandler,
+  useEffect,
 } from 'react';
 import { TableInstance, Hooks } from 'react-table';
 import getScrollBarSize from '../utils/getScrollBarSize';
@@ -309,6 +310,21 @@ function StickyWrap({
       </div>
     );
   }
+
+  useEffect(() => {
+    const bodyElement = scrollBodyRef?.current;
+    const headerElement = scrollHeaderRef?.current;
+
+    if (bodyElement && headerElement && colWidths && bodyHeight) {
+      const isChrome =
+        /Chrome/.test(navigator.userAgent) &&
+        /Google Inc/.test(navigator.vendor);
+      headerElement.style.paddingRight =
+        bodyElement.scrollHeight > bodyElement.clientHeight && isChrome
+          ? '17px'
+          : '0px';
+    }
+  }, [bodyHeight, colWidths, scrollBodyRef]);
 
   return (
     <div


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
In the Table chart, when vertical scroll appears when using Chrome browser, the table columns are shifted relative to the table headers. This PR fixes the alignment of table headers and columns for Chrome.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
Before:
![изображение](https://github.com/TechAudit-BI/superset/assets/76280175/dabaf3b6-15eb-4d7a-8553-e63d17a7c0fa)

After:
![изображение](https://github.com/TechAudit-BI/superset/assets/76280175/8c10cb5b-99bc-4c62-bfee-7ddcd03623eb)

### TESTING INSTRUCTIONS
- Open a Table chart in Chrome browser. 
- Set the row limit to 100, for example, so that the table has a vertical scroll.
- The table header should not move when the vertical scroll appears and disappears, for example, when changing the row limit value from 100 to 10.

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [ ] Has associated issue:
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
